### PR TITLE
Fix cookies consent

### DIFF
--- a/app/assets/stylesheets/cookies.scss
+++ b/app/assets/stylesheets/cookies.scss
@@ -1,13 +1,21 @@
 .cookies-eu {
-  opacity: 0;
   position: fixed;
-  margin-top: 0;
+  bottom: 0;
+  left: 0;
   background: #333333;
+  padding: 0;
 
   .cookies-eu-content-holder {
+    max-width: 85% !important;
     color: white;
+    font-size: 12px;
+    padding: 20px;
+    text-align: left;
+    line-height: 1em;
   }
 
-  .cookies-eu-button-holder{
+  .cookies-eu-button-holder {
+    padding-right: 0;
+    margin-top: 10px;
   }
 }

--- a/app/assets/stylesheets/mediaqueries.scss
+++ b/app/assets/stylesheets/mediaqueries.scss
@@ -4,19 +4,6 @@
   }
 }
 @media #{$small-only} {
-  .cookies-eu {
-    .cookies-eu-content-holder {
-      display: block !important;
-      max-width: 85% !important;
-      text-align: left;
-      float: left;
-    }
-    .cookies-eu-button-holder{
-      padding-right: 0;
-      float: left;
-      margin-top: 10px;
-    }
-  }
   .home {
     .intro {
       .container {

--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -28,10 +28,6 @@ ul{
   list-style: none;
 }
 
-.cookies-eu{
-  margin-top:50px;
-}
-
 .disable{
   opacity: 0.65;
   a{

--- a/spec/features/cookies_consent_spec.rb
+++ b/spec/features/cookies_consent_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+feature "Cookies consent" do
+  scenario "is shown" do
+    visit root_path
+
+    expect(page).to have_css(".cookies-eu")
+    expect(page).to have_content("Las cookies nos ayudan a ofrecer nuestros servicios.")
+  end
+
+  scenario "is not shown when cokies already accepted", :js do
+    visit root_path
+
+    within(".cookies-eu") do
+      click_on "OK"
+    end
+
+    expect(page).not_to have_css(".cookies-eu")
+    expect(page).not_to have_content("Las cookies nos ayudan a ofrecer nuestros servicios.")
+
+    visit root_path
+
+    expect(page).not_to have_css(".cookies-eu")
+    expect(page).not_to have_content("Las cookies nos ayudan a ofrecer nuestros servicios.")
+  end
+
+  scenario "after click on OK button cookies consent is hidden", :js do
+    visit root_path
+
+    within(".cookies-eu") do
+      click_on "OK"
+    end
+
+    expect(page).not_to have_css(".cookies-eu")
+    expect(page).not_to have_content("Las cookies nos ayudan a ofrecer nuestros servicios.")
+  end
+end


### PR DESCRIPTION
After removal of cookies consent animation i forgot to remove `opacity` property from css.

Add some feature specs so this will no happen again.

Use same styles for all devices.