### PR TITLE
Initialize notice rendered through AJAX

### DIFF
--- a/app/views/consul/contacts/create.js.erb
+++ b/app/views/consul/contacts/create.js.erb
@@ -1,2 +1,3 @@
 $('#contact-notice-placeholder').html("<%= j (render 'shared/notice') %>");
 $('#new_contact').replaceWith("<%= j (render 'shared/contact/form', contact: @contact, url: consul_contacts_path, remote: true ) %>");
+$(document).foundation('alert', 'reflow');

--- a/spec/features/consul/contact_spec.rb
+++ b/spec/features/consul/contact_spec.rb
@@ -40,6 +40,23 @@ feature 'Contact', :js do
     expect(ActionMailer::Base.deliveries.size).to eq(0)
   end
 
+  scenario 'can close notice after successful send', :js do
+    visit consul_development_services_path
+    page.current_window.resize_to(1200, 3000)
+
+    fill_in 'contact_name', with: "My Name"
+    fill_in 'contact_email', with: "email@example.es"
+    fill_in 'contact_message', with: "Solicitud de contacto"
+    click_on 'Enviar mensaje'
+
+    expect(page).to have_content "Gracias por contactar con nosotros. Te responderemos lo antes posible."
+    within ".alert-box" do
+      find(".close").click
+    end
+
+    expect(page).not_to have_content "Gracias por contactar con nosotros. Te responderemos lo antes posible."
+  end
+
   describe "timestamp spam detection" do
     before do
       InvisibleCaptcha.timestamp_enabled = true


### PR DESCRIPTION
As it's says at Foundation:

> If you add new content after the page has been loaded, you will need to reinitialize the Foundation JavaScript by running the following:

> `$(document).foundation();`

> Reflow will make Foundation check the DOM for any elements and
> re-apply any listeners to them.

> $(document).foundation('alert', 'reflow');

https://get.foundation/sites/docs-v5/components/alert_boxes.html